### PR TITLE
fix: update to config removing gensis chainId

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -16,5 +16,3 @@ faucet:
   coins: ["5snr", "100000stake"]
 build:
   binary: "sonrd"
-genesis:
-  chain_id: "i95"


### PR DESCRIPTION
- removal of gensis chainId preventing acct name querying due to conflicting chainId's on highway

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>